### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     github-pages (150)
       activesupport (= 4.2.8)
       github-pages-health-check (= 1.3.5)
-      jekyll (= 3.5.1)
+      jekyll (= 3.6.3)
       jekyll-avatar (= 0.4.2)
       jekyll-coffeescript (= 1.0.1)
       jekyll-default-layout (= 0.1.4)


### PR DESCRIPTION
Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows attackers to access arbitrary files by spec...

update suggested:
jekyll ~> 3.6.3